### PR TITLE
fixed error where invalid include name would cause hang

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -602,14 +602,17 @@ function route(name, model, inflect) {
   function linkedIds(resources, path, schema) {
     var ids = [];
     _.each(resources, function(resource) {
-      var isExt = (_.isArray(schema[path]) ? schema[path][0] : schema[path]).external;
 
-      if (resource.links && resource.links[path] && !isExt) {
-        var id = resource.links[path];
-        if (_.isArray(id)) {
-          ids = ids.concat(id);
-        } else {
-          ids.push(id);
+      if (_.isArray(schema[path])) {
+        var isExt = (_.isArray(schema[path]) ? schema[path][0] : schema[path]).external;
+
+        if (resource.links && resource.links[path] && !isExt) {
+          var id = resource.links[path];
+          if (_.isArray(id)) {
+            ids = ids.concat(id);
+          } else {
+            ids.push(id);
+          }
         }
       }
     });
@@ -673,7 +676,7 @@ function route(name, model, inflect) {
             .then(function(result) {
               var relation = _.isArray(schema[key]) ? schema[key][0] : schema[key];
 
-              if(relation.external){
+              if(relation && relation.external){
                 var pluralisedRef = inflect.pluralize(relation.ref || key);
                 body.linked[pluralisedRef] = "external";
                 body.links[linkpath + "." + key] = {type: pluralisedRef};


### PR DESCRIPTION
Fixed an issue where submitting an invalid include would cause the request to hang.

Solution was to add some defensive coding as currently the code assumes that the path exists in the schema. If it doesn't we get exceptions and the promise never resolves.

Added guard to that if path (include name) didn't exist in the schema it wouldn't cause a crash:

```
 if (_.isArray(schema[path])) {
```

Same thing with the line here:

```
 if(relation && relation.external){
```
