### PR TITLE
Feature meta.total and ?offset filter

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -135,6 +135,14 @@ Adapter.prototype.findMany = function () { return stubPromise(); };
  */
 Adapter.prototype.awaitConnection = function () { return stubPromise(true); };
 
+/**
+ * Return the total amount of resources in the database.
+ *
+ * @param {String|Object} model either a string or the underlying model
+ * @return {[type]}   [description]
+ */
+Adapter.prototype.total = function() { return stubPromise(); };
+
 
 /**
  * Stub promise returner.

--- a/lib/adapters/mongodb.js
+++ b/lib/adapters/mongodb.js
@@ -253,7 +253,7 @@ adapter.findMany = function(model, query, projection) {
 
   function parseQuery(query){
     query = _.clone(query);
-    
+
     _.each(query, function(val, key){
       var m;
       if(_.isNull(val) || _.isUndefined(val)){
@@ -375,6 +375,23 @@ adapter.awaitConnection = function () {
     });
     _this.db.once('error', function (error) {
       reject(error);
+    });
+  });
+};
+
+/**
+ * Return total amount of resources (count without filter)
+ *
+ * @param model {Model || String}
+ * @return {promise}
+ */
+adapter.total = function(model) {
+  model = typeof model == 'string' ? this._models[model] : model;
+
+  return new Promise(function(resolve, reject) {
+    model.count(function(err, count) {
+      if (err) reject(err);
+      else resolve(count);
     });
   });
 };

--- a/lib/adapters/mongodb.js
+++ b/lib/adapters/mongodb.js
@@ -321,7 +321,7 @@ adapter.findMany = function(model, query, projection) {
   projection = projection || {};
   projection.limit = projection.limit || model.schema.options.defaultLimit || 1000;
   projection.select = projection.select || '';
-  projection.skip = 0;
+  projection.skip = (! isNaN(_.parseInt(projection.skip))) ? projection.skip : 0;
 
   if (projection.page && projection.page > 0) {
     projection.skip = (projection.page - 1) * projection.pageSize;

--- a/lib/route.js
+++ b/lib/route.js
@@ -38,6 +38,7 @@ function route(name, model, resources, inflect, querytree) {
   , namespace = this.options.namespace
   , suffix = this.options.suffix
   , production = this.options.production
+  , includeMeta = this.options.includeMeta
 
   // routes
   , collection = inflect.pluralize(name)
@@ -364,6 +365,7 @@ function route(name, model, resources, inflect, querytree) {
     var ids = [];
     var projection = {};
     var select = parseSelectProjection(req.query.fields, inflect.pluralize(model.modelName));
+    var meta = {};
 
     if(req.query.ids) match.id = {$in: req.query.ids.split(',')};
 
@@ -399,8 +401,22 @@ function route(name, model, resources, inflect, querytree) {
     beforeReadHook({}, req, res)
       .then(function(){
         // get resources by IDs
-        return querytree.parse(model.modelName, _.extend(match, req.query.filter)).then(function(query){
-          return adapter.findMany(model, query, projection);
+        var promises = {
+          resources: querytree.parse(model.modelName, _.extend(match, req.query.filter)).then(function(query){
+              return adapter.findMany(model, query, projection);
+            })
+        };
+
+        // Include meta.total?
+        if(includeMeta) {
+          promises.total = adapter.total(model);
+        }
+
+        return RSVP.hash(promises).then(function(results) {
+          // cache meta total
+          meta.total = (includeMeta) ? results.total : undefined;
+          // Hand over resources to promise chain
+          return results.resources;
         });
       }, function(err){
         sendError(req, res, 500, err);
@@ -419,6 +435,9 @@ function route(name, model, resources, inflect, querytree) {
       .then(function(resources) {
         var body = {};
         body[collection] = resources;
+        if(includeMeta) {
+          body.meta = meta;
+        }
         sendResponse(req, res, 200, body);
       }, function(error) {
         sendError(req, res, 403, error);
@@ -440,6 +459,7 @@ function route(name, model, resources, inflect, querytree) {
     var match = {};
     var ids = req.params.id.split(',');
     var projection;
+    var meta = {};
 
     if (booster.canBoost(req)){
       req.linker = booster.startLinking(req);
@@ -449,7 +469,7 @@ function route(name, model, resources, inflect, querytree) {
     if (select){
       projection = {
         select: select
-      }
+      };
     }
 
     if(ids){
@@ -465,7 +485,22 @@ function route(name, model, resources, inflect, querytree) {
       .then(function(){
         // get resources by IDs
         match = req.query.filter;
-        return adapter.findMany(model, match, projection);
+
+        var promises = {
+          resources: adapter.findMany(model, match, projection)
+        };
+
+        // Include meta.total?
+        if(includeMeta) {
+          promises.total = adapter.total(model);
+        }
+
+        return RSVP.hash(promises).then(function(results) {
+          // cache meta total
+          meta.total = (includeMeta) ? results.total : undefined;
+          // Hand over resources to promise chain
+          return results.resources;
+        });
       }, function(err){
         sendError(req, res, 500, err);
       })
@@ -487,6 +522,9 @@ function route(name, model, resources, inflect, querytree) {
       .then(function(resources) {
         var body = {};
         body[collection] = resources;
+        if(includeMeta) {
+          body.meta = meta;
+        }
         sendResponse(req, res, 200, body);
       }, function(error) {
         sendError(req, res, 500, error);
@@ -926,11 +964,11 @@ function route(name, model, resources, inflect, querytree) {
          *
          * however, this may be an indicator of a broader design issue where it's hard for the
          * library code to distinguish between the native and custom request properties which
-         * may cause inconsistent behaviour 
+         * may cause inconsistent behaviour
          *
          * suggested solution: nesting custom properties, e.g. req.custom.linker = linker
          */
-        linker: undefined 
+        linker: undefined
       })).then(function(response){
         deferred.resolve({
           type: collection,

--- a/lib/route.js
+++ b/lib/route.js
@@ -380,6 +380,10 @@ function route(name, model, resources, inflect, querytree) {
       projection.sort = req.query.sort;
     }
 
+    if (req.query.offset){
+      projection.skip = req.query.offset;
+    }
+
     if (req.query.page){
       projection.page = req.query.page;
 

--- a/test/fortune/fields_and_filters.js
+++ b/test/fortune/fields_and_filters.js
@@ -634,5 +634,21 @@ module.exports = function(options){
           });
       });
     });
+
+    describe('offset', function() {
+      it('should be possible to offset results', function(done){
+        request(baseUrl).get('/people?sort=name&limit=2&offset=1')
+          .expect(200)
+          .end(function(err, res){
+            should.not.exist(err);
+            var body = JSON.parse(res.text);
+            console.log(body);
+            (body.people.length).should.equal(2);
+            _.pluck(body.people, "name").should.eql(["Robert", "Sally"]);
+            done();
+          });
+      });
+    });
+
   });
 };

--- a/test/fortune/fields_and_filters.js
+++ b/test/fortune/fields_and_filters.js
@@ -642,7 +642,6 @@ module.exports = function(options){
           .end(function(err, res){
             should.not.exist(err);
             var body = JSON.parse(res.text);
-            console.log(body);
             (body.people.length).should.equal(2);
             _.pluck(body.people, "name").should.eql(["Robert", "Sally"]);
             done();


### PR DESCRIPTION
Adds the ?offset= filter and a switch in `options.includeMeta` to toggle output of `meta.total` in response. With `options.includeMeta` enable the query and the total count will happen in parallel.

I wanted to split the features in two pull-requests, but it did not work out the way I intended...