### PR TITLE
Debug mode for logging all requests to underlying database

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Contributions welcome.
 
 ### Changes since fork of daliwali/fortune
 
+- Debug option for logging all db requests
 - Select fields to return: `/people?fields=name,age`  (see [acdb09b](//github.com/flyvictor/fortune/commit/acdb09b2cad568c0dd0e7e27fc22b6362e996f2c))
 - Specif express instance in fortune options (see [0413a74](//github.com/flyvictor/fortune/commit/0413a74f3c1a7c9971f8cac4eecf77284503e2f1))
 - Control if linked documents are included in the response `/people?include=pets` (see [92c80f3](//github.com/flyvictor/fortune/commit/92c80f3b8363242a8cb57a33e20f6d4b57a04055))
@@ -49,7 +50,7 @@ Here is a minimal application:
 
 ```javascript
 var fortune = require('fortune');
-var app = fortune();
+var app = fortune({ /* debug: true */ });
 
 app.resource('person', {
   name: String,

--- a/lib/adapters/mongodb.js
+++ b/lib/adapters/mongodb.js
@@ -14,6 +14,8 @@ adapter._init = function (options) {
       options.host + (options.port ? ':' + options.port : '') + '/' + options.db;
   }
 
+  mongoose.set('debug', options.debug);
+
   //Setup mongoose instance
   this.db = mongoose.createConnection(connectionString, options.flags);
 };

--- a/test/fortune/all.js
+++ b/test/fortune/all.js
@@ -5,6 +5,7 @@ var RSVP = require('rsvp');
 var request = require('supertest');
 var Promise = RSVP.Promise;
 var fixtures = require('../fixtures.json');
+var fortune = require('../../')
 
 module.exports = function(options){
 
@@ -57,6 +58,17 @@ describe('Fortune', function () {
     });
   });
 
-});
+  describe("Init", function() {
+    it("Should pass 'debug' option to underlying adapter", function(done) {
+      var app = fortune({
+        adapter: 'mongodb',
+        debug: true
+      });
 
+      app.adapter.mongoose.options.debug.should.equal(true);
+      app.adapter.mongoose.options.debug = false; // Set the global variable back to not log all requests in test env
+      done();
+    });
+  });
+});
 };

--- a/test/fortune/all.js
+++ b/test/fortune/all.js
@@ -4,8 +4,7 @@ var _ = require('lodash');
 var RSVP = require('rsvp');
 var request = require('supertest');
 var Promise = RSVP.Promise;
-var fixtures = require('../fixtures.json');
-var fortune = require('../../')
+var fortune = require('../../lib/fortune.js')
 
 module.exports = function(options){
 
@@ -18,6 +17,18 @@ describe('Fortune', function () {
     app = options.app;
   });
 
+  describe("Init", function() {
+    it("should pass 'debug' option to underlying adapter", function(done) {
+      var app = fortune({
+        adapter: 'mongodb',
+        debug: true
+      });
+
+      app.adapter.mongoose.options.debug.should.equal(true);
+      app.adapter.mongoose.options.debug = false; // Set the global variable back to not log all requests in test env
+      done();
+    });
+  });
 
   require('./actions')(options);
   require('./routing')(options);
@@ -58,17 +69,5 @@ describe('Fortune', function () {
     });
   });
 
-  describe("Init", function() {
-    it("Should pass 'debug' option to underlying adapter", function(done) {
-      var app = fortune({
-        adapter: 'mongodb',
-        debug: true
-      });
-
-      app.adapter.mongoose.options.debug.should.equal(true);
-      app.adapter.mongoose.options.debug = false; // Set the global variable back to not log all requests in test env
-      done();
-    });
-  });
 });
 };

--- a/test/fortune/all.js
+++ b/test/fortune/all.js
@@ -17,18 +17,6 @@ describe('Fortune', function () {
     app = options.app;
   });
 
-  describe("Init", function() {
-    it("should pass 'debug' option to underlying adapter", function(done) {
-      var app = fortune({
-        adapter: 'mongodb',
-        debug: true
-      });
-
-      app.adapter.mongoose.options.debug.should.equal(true);
-      app.adapter.mongoose.options.debug = false; // Set the global variable back to not log all requests in test env
-      done();
-    });
-  });
 
   require('./actions')(options);
   require('./routing')(options);
@@ -69,5 +57,21 @@ describe('Fortune', function () {
     });
   });
 
+  describe("Init", function() {
+    it("should pass 'debug' option to underlying adapter", function(done) {
+      var remoteDB = process.env.WERCKER_MONGODB_URL ? process.env.WERCKER_MONGODB_URL + '/fortune' : null;
+      var app = fortune({
+        adapter: 'mongodb',
+        debug: true,
+        connectionString: remoteDB || "mongodb://localhost/fortune_test",
+        inflect: true,
+        enableWebsockets: true
+      });
+
+      app.adapter.mongoose.options.debug.should.equal(true);
+      app.adapter.mongoose.options.debug = false; // Set the global variable back to not log all requests in test env
+      done();
+    });
+  });
 });
 };

--- a/test/fortune/routing.js
+++ b/test/fortune/routing.js
@@ -237,7 +237,6 @@ module.exports = function(options){
               .end(function(err, res){
                 should.not.exist(err);
                 var body = JSON.parse(res.text);
-                console.log(body.people);
                 body.people.length.should.be.greaterThan(0);
                 done();
               });


### PR DESCRIPTION
The 'debug' option allows underlying db adapter to log all requests to console:
```Shell
Mongoose: people.update({ lovers: 'wally@mailbert.com' }) { '$pull': { lovers: 'wally@mailbert.com' } } { multi: true } 
Mongoose: cars.update({ owner: 'wally@mailbert.com' }) { '$unset': { owner: 1 } } {} 
Mongoose: houses.update({ owners: 'wally@mailbert.com' }) { '$pull': { owners: 'wally@mailbert.com' } } { multi: true } 
Mongoose: addresses.update({ person: 'wally@mailbert.com' }) { '$unset': { person: 1 } } {} 
Mongoose: houses.update({ landlord: 'wally@mailbert.com' }) { '$unset': { landlord: NaN } } {}
```
This simplifies application analyze without reliance on (sometimes shared) database profiling level / log.