### PR TITLE
Resource aggregates

### DIFF
--- a/test/fortune/aggregates.js
+++ b/test/fortune/aggregates.js
@@ -1,0 +1,137 @@
+'use strict';
+var should = require('should');
+var request = require('supertest');
+
+module.exports = function (options) {
+  describe('resource aggregates', function () {
+    var baseUrl;
+    beforeEach(function () {
+      baseUrl = options.baseUrl;
+    });
+
+    describe('reject all methods except GET', function () {
+      it('should respond 403 to POST', function (done) {
+        request(baseUrl).post('/aggregates')
+          .set('content-type', 'application/json')
+          .send(JSON.stringify({}))
+          .expect(403)
+          .end(function (err, res) {
+            should.not.exist(err);
+
+            done();
+          });
+      });
+
+      it('should respond 403 to PUT', function (done) {
+        request(baseUrl).put('/aggregates')
+          .set('content-type', 'application/json')
+          .send(JSON.stringify({}))
+          .expect(403)
+          .end(function (err, res) {
+            should.not.exist(err);
+
+            done();
+          });
+      });
+
+      it('should respond 403 to PATCH', function (done) {
+        request(baseUrl).patch('/aggregates')
+          .set('content-type', 'application/json')
+          .send(JSON.stringify({}))
+          .expect(403)
+          .end(function (err, res) {
+            should.not.exist(err);
+
+            done();
+          });
+      });
+
+      it('should respond 403 to DELETE', function (done) {
+        request(baseUrl).delete('/aggregates')
+          .set('content-type', 'application/json')
+          .send(JSON.stringify({}))
+          .expect(403)
+          .end(function (err, res) {
+            should.not.exist(err);
+
+            done();
+          });
+      });
+
+      it('should respond 200 to GET', function (done) {
+        request(baseUrl).get('/aggregates')
+          .set('content-type', 'application/json')
+          .send(JSON.stringify({}))
+          .expect(200)
+          .end(function (err, res) {
+            should.not.exist(err);
+
+            done();
+          });
+      });
+
+
+    });
+
+
+    it('should create a new aggregates resource route', function (done) {
+      request(baseUrl).get('/aggregates')
+        .set('content-type', 'application/json')
+        .send(JSON.stringify({}))
+        .end(function (err, res) {
+          should.not.exist(err);
+          var body = JSON.parse(res.text);
+          body.data.should.be.an.Array;
+          body.data.length.should.equal(0);
+
+          done();
+        });
+    });
+
+    it('should create a new aggregates resource route', function (done) {
+      request(baseUrl).get('/aggregates')
+        .set('content-type', 'application/json')
+        .send(JSON.stringify({}))
+        .expect(200)
+        .end(function (err, res) {
+          should.not.exist(err);
+          var body = JSON.parse(res.text);
+          body.data.should.be.an.Array;
+          body.data.length.should.equal(0);
+
+          done();
+        });
+    });
+
+    it('should return an empty dataset when an invalid dataset is specified', function (done) {
+      request(baseUrl).get('/aggregates?dataset=nonExistentDataset')
+        .set('content-type', 'application/json')
+        .send(JSON.stringify({}))
+        .expect(200)
+        .end(function (err, res) {
+          should.not.exist(err);
+          var body = JSON.parse(res.text);
+          body.data.should.be.an.Array;
+          body.data.length.should.equal(0);
+
+          done();
+        });
+    });
+
+    it('should return a collection of objects when a valid dataset is specified', function (done) {
+      request(baseUrl).get('/aggregates?dataset=aggregate-by-day')
+        .set('content-type', 'application/json')
+        .send(JSON.stringify({}))
+        .expect(200)
+        .end(function (err, res) {
+          should.not.exist(err);
+          var body = JSON.parse(res.text);
+          body.data.should.be.an.Array;
+          body.data.length.should.be.greaterThanOrEqual(1);
+          body.data[0].should.be.an.Object;
+
+          done();
+        });
+    });
+  });
+};

--- a/test/fortune/all.js
+++ b/test/fortune/all.js
@@ -19,6 +19,7 @@ describe('Fortune', function () {
 
 
   require('./actions')(options);
+  require('./aggregates')(options);
   require('./routing')(options);
   require('./associations')(options);
   require('./fields_and_filters')(options);
@@ -48,7 +49,7 @@ describe('Fortune', function () {
 
     it("is indexed and unique", function(done){
       var model;
-      
+
       (model = app.adapter.model("person")).collection.getIndexes(function(err,indexData){
         model.pk.should.be.ok;
         indexData[model.pk+"_1"].should.be.ok


### PR DESCRIPTION
_Note: This branch contains failing tests only. Do not merge prior to discussion and implementation of proposed solution below._

## Aim

The goal is to open up aggregate data made from existing fortune resources. 

Examples would be allowing a client to:

- Fetch total user registrations per day
- Ecommerce transaction totals per week
- Custom data set projections such as monthly min, max, averages etc

____________________________________

## Initial proposed route

First instincts would be to configure resource actions to allow you to provide an adapter specific aggregation configuration.  Taken from the Github issue flyvictor/fortune#133 outlining the requirements, this could be:


```
resource("user", {...}, {
 "actions" : {
   "aggregate-by-day" : {
     type : "aggregate",
     config :[ 
		{ $match : { "joinDate" : { $ne : null, $gte : ISODate("2014-01-01") } },
		{ $project: {
		    year: { $year: "$joinDate" },
		    month: { $month: "$joinDate" },
		    day: { $dayOfMonth: "$joinDate" }
		}},
		{ $group : { _id : { year : "$year", month : "$month", day : "$day" }, count : { $sum : 1 } } },
		{ $sort : { "_id.year" : -1, "_id.month" : -1, "_id.day" : -1 } }
	]
   }
 }
 ```
 
 From an API standpoint this is effective since it uses an existing configuration paradigm (actions) and also allows the user to specify adapter specific configuration.
 
## Issues with proposed route

Some technical scoping of this route leads to several problems:

### 1. Actions are bound to  resource items

FortuneJS is configured to only trigger actions on an existing resource. Using the example given in the repository:

```
POST: http://localhost/users/test@test.com/send-password-reset
```
 
Contextually, this makes sense since you are triggering mechanics to reset the resources password and send an email. This entire operation hinges on the existence of a resource in order to function.

Similarly, specifying multiple resource identifiers still makes contextual sense:

```
POST: http://localhost/users/user1@test.com,user2@test.com/disable-accounts
```

In this case, the disable accounts action has multiple resources specified to which it can apply its functionality.

For aggregation data sets, this functionality only works if you implement an aggregation based on resources links or related data. This presents a problem when you attempt to aggregate data across top level resources:

```
//REST API for aggregating # user likes per day makes sense:
POST: http://localhost/users/user1@test.com/aggregate-likes-per-day

//REST API for aggregating user registrations per day doesnt make sense 
//because you must start by specifying a resource but need to work across them:
POST: http://localhost/users/user1@test.com/aggregate-signups-per-day

```

### 2. Semantics & JSON API rules

Even if we resolve issue point 1 above by modifying actions to work at the resource collection level, we still encounter problems.

For example:

```
POST: http://localhost/member/aggregate-signups-per-day
```

Although the URI pattern above is fairly clear with regard to intent, we incur semantic headaches and also run afoul of the JSON API standard.


1.	*Semantics*

	Conceptually a returned aggregation set has no contract to return resource items with correct resource fields. It is far more likely that an aggregation set will comprise of new objects containing compound fields made from map/reducing multiple resource fields.

	Additionally the resulting JSON object will most likely need to resort to the generic "data" key (further obfuscating things) since the grouping used for the segmentations could be any number of resource fields.

	This means the API becomes unpredictable when encountering an aggregation action as part of a resource definition.

	Example:

	```
	// ...
	// Given the fortune resource:
	app.resource("member", {
	    title: String,
	    firstName: String,
	    lastName: String,
	    email: String
	});

	//A URL request to a collection action:
	POST: http://localhost/member/aggregate-signups-per-day

	//The returned data structure shouldnt use the "member" root key 
	//since grouping is based on date in this example
	RESULT HEADER: 200
	RESULT BODY:
	{
		data: [
			{
				count: 23,
				date: "2015-03-21"
			},
			{
				count: 14,
				date: "2015-03-20"
			},
			{
				count: 16,
				date: "2015-03-19"
			}
			// ....
		]
	}
	```

2.	*JSON API Rules*

	Adding reserved keywords to a resource path is never a good idea and goes against the JSON API rules; The segment used after a resource type declaration must always be a resource ID.

	Breaking the JSON API rules would couple the UI client to the backend implementation since the client would not be swappable with any JSON API compliant client module.


### 3. Actions are not safe or indempotent

There are two issues with regard to the current resource item & action route binding configuration that cause problems with aggregation sets:

*	*Fetching an aggregation set should be indepotent & safe*

	This means that aggregation set fetching should be performed over GET (see below), produce the same result when called repeatedly, have no side effect and not modify any resources. Currently actions are _designed_ to modify or have side effects with regard to a specified resource since it appears that is what drove their original implementation.
	
*	*Fortune actions do not work with GET methods*

	The underlying engineering in Fortune does not allow action methods to be performed over GET. Only POST, PUT, PATCH methods work. From a quick scan of the code it appears to be due to the middleware definition order, but it would need some very intrusive modification in order to get this to work.

## New proposition

Given the issues outlines above with regard to a resouce action driven route, I believe a resolution can be found in considering aggregation sets as resources themselves, which can then have filters and sorting applied.

I propose some key differences, however:

-	Resource IDs may or may not be returned in a response but they cannot be specified via the REST API. This means that you would not be able to drill down into a specific returned collection item & fields like you would a standard resource route.
	This enforces the concept of aggregates are always returned in sets but also that you are viewing a data projection, not a collection of resources.
-	A `dataset` parameter would be required.  Although requiring a query to be present to make a request is never ideal, this route will make the aggregate route behave just like a standard JSON API resource.
-	Specifying aggregations like a resource removes the binding between aggregations and resource items, and also makes the API cleaner.

Config based example:

```
var app = fortune(options);

//Standard resource definition
app.resource("user", {
	name: String,
	joinDate: Date
	// ...
});

//New aggregate method on fortune app instance
app.aggregate("userSignupsPerDay", {
	//Specify the resource to perform the aggregation on
	resource: "user"
	
	//Adapter specific aggregation configuration (in this case mongodb)
	config: [
		{ $match : 
			{ "joinDate" : { $ne : null, $gte : new Date("2014-01-01") } } },
		{ $project: {
 		    year: { $year: "$joinDate" },
 		    month: { $month: "$joinDate" },
 		    day: { $dayOfMonth: "$joinDate" }
 		}},
		{ $group : { 
			_id : { year : "$year", month : "$month", day : "$day" }, count : { $sum : 1 } } 
		},
		{ $sort : { 
			"_id.year" : -1, "_id.month" : -1, "_id.day" : -1 } 
		}
	]
});
 ```

Given the configuration above which defines a user resource and a "userSignupsPerDay" aggregation, the REST API could behave like so:

```
GET: http://localhost/aggregate

RESULT HEADER: 200
RESULT BODY:
{
	data: []
}

//------

GET: http://localhost/aggregate?dataset=nonExistentAggregateName

RESULT HEADER: 200
RESULT BODY:
{
	data: []
}

//Although this is not ideal, it is logically correct. If we returned 
//a 404, a user could hammer the aggregates endpoint to discover all 
//existing datasets

//------

GET: http://localhost/aggregate?dataset=userSignupsPerDayGET: http://localhost/aggregate?dataset=userSignupsPerDay


RESULT HEADER: 200
RESULT BODY:
{
	data: [
		{
			count: 23,
			date: "2015-03-21"
		},
		{
			count: 14,
			date: "2015-03-20"
		},
		{
			count: 16,
			date: "2015-03-19"
		}
		// ....
	]
}
```

The above URI pattern would remain compliant with any JSON API compatible client and also ensure that standard sort, pagination, filter queries remain functional.

With some work you could even allow specific datasets to allow query string parameters to control the aggregation mechanism.  This would be ideal for:

-	Allowing users to specify the segmentation. For example for a years worth of transaction data, being able to specify grouping by day, week or month
-	Aggregate and return transaction data over a certain financial threshold

---------

#### A note on segment aggregate/dataset URI pattern

Although you could implement this as an API involving URI segments only such as:

```
GET: http://localhost/aggregate/userSignupsPerDay
```

I believe this simply ends up polluting the API with what looks like multiple resource/ID URIs that are not resources and IDs! Every aggregate configuration could return wildly different datasets and segments, making anything under the "/aggregation/*" URI the wild wild west.  

If we are going to introduce a reserved keyword I believe it would be best to limit to the single "aggregates".

----------

## Pull request and next steps

This pull request is intended to begin discussion and track implementation of this feature.

At this point it contains solely failing tests to act as a starting point, however, there are still implementation details that must be determined such as:

-	_Specifying a resource as part of the aggregation config_

	Likely not necessary if the config was an anonymous function. Would need to standardise the expected pattern of configuration.
-	_Mechanisms for advanced usage_

	Essentially a callback called on each request. User could specify what resources the callback depended on and (in the case of mongodb) have the Mongoose Models provided as arguments allowing the user to provide advanced usage.
	
-	_Async support for building aggregation sets_

	Similar to the advanced usage above, but users might need to perform async operations that cannot be accomplished within a single aggregation config command (e.g. fetch & integrate third party data or different local dataset). Could be as simple as allowing the user to return Promises as part of the config setup or route event.