### PR TITLE
Improve error handling

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -159,6 +159,24 @@ function stubPromise (silent) {
   });
 }
 
+/**
+ * Error wrapper to normalize all adapter errors. Normalized codes shall follow
+ * HTTP status codes convention. Adapter implementations shall use this wrapper
+ * to signal their error codes were already normalized.
+ *
+ * @param {Number} code normalized error code
+ * @param {String} msg human readable error message (optional)
+ * @param {Error} err original adapter error
+ * @return {Error}
+ */
+Adapter.prototype.toError = function (code, msg, err) {
+  var e = new Error();
+  e.name = "AdapterError";
+  e.code = code;
+  e.message = msg || err.message;
+  e.wrapped = err || msg;
+  return e;
+};
 
 exports = module.exports = Adapter;
 exports.adapters = adapters;

--- a/lib/adapters/mongodb.js
+++ b/lib/adapters/mongodb.js
@@ -612,6 +612,25 @@ adapter._deserialize = function (model, resource) {
 };
 
 /**
+ * Converts MongoDB errors to HTTP status codes to use normalized error code
+ + responses across the adapter.
+ *
+ * @param {Error} error is the MongoDB error
+ * @return {Error} containing a normalized error code
+ */
+adapter._normalizeError = function (error) {
+  if (error.name !== "MongoError") {
+    return error;
+  }
+  switch (error.code) {
+    case 11000: // duplicate key error
+    return this.toError(409, error); // Conflict
+    default:
+    return error;
+  }
+};
+
+/**
  * What happens after the DB has been written to, successful or not.
  *
  * @api private
@@ -625,7 +644,7 @@ adapter._deserialize = function (model, resource) {
 adapter._handleWrite = function (model, resource, error, resolve, reject, modifiedRefs) {
   var _this = this;
   if (error) {
-    return reject(error);
+    return reject(_this._normalizeError(error));
   }
   this._updateRelationships(model, resource, modifiedRefs).then(function(resource) {
     resolve(_this._deserialize(model, resource));

--- a/lib/route.js
+++ b/lib/route.js
@@ -80,6 +80,13 @@ function route(name, model, resources, inflect, querytree, metadataProviders) {
     res.set('Content-Type', MIME.standard[1]);
     res.send(status, str);
   };
+  var sendAdapterError = function (req, res, error) {
+    if (error.name === "AdapterError") {
+      sendError(req, res, error.code, error);
+    } else {
+      sendError(req, res, 500, error);
+    }
+  };
   var sendResponse = function (req, res, status, object) {
     if (status === 204) return res.send(status);
 
@@ -361,11 +368,7 @@ function route(name, model, resources, inflect, querytree, metadataProviders) {
             return afterWriteHook(modelName, resource, req, res);
           })).then(terminateOnRejectedHooks);
         }, function(error) {
-          if (error.name === "MongoError" && error.code === 11000) { // E11000 duplicate key error
-            sendError(req, res, 409, error);
-          } else {
-            sendError(req, res, 500, error);
-          }
+          sendAdapterError(req, res, error);
         });
     }
 

--- a/lib/route.js
+++ b/lib/route.js
@@ -361,7 +361,11 @@ function route(name, model, resources, inflect, querytree, metadataProviders) {
             return afterWriteHook(modelName, resource, req, res);
           })).then(terminateOnRejectedHooks);
         }, function(error) {
-          sendError(req, res, 500, error);
+          if (error.name === "MongoError" && error.code === 11000) { // E11000 duplicate key error
+            sendError(req, res, 409, error);
+          } else {
+            sendError(req, res, 500, error);
+          }
         });
     }
 

--- a/test/fortune/multitenant-integration.js
+++ b/test/fortune/multitenant-integration.js
@@ -45,7 +45,7 @@ module.exports = function(options){
             .send(JSON.stringify({people: [
               {email: 'dilbert@mailbert.com', _tenantId: 'testing'}
             ]}))
-            .expect(500)
+            .expect(409)
             .end(function(err){
               should.not.exist(err);
               done();


### PR DESCRIPTION
@EugeneKostrikov as discussed in #150, this PR implements the minimum framework to normalize the error responses generated in the adapters so the router can properly manage those errors instead of assuming there are all internal issues processing the request such as connection errors, database driver crashes and so on.

The normalized error codes convention was aligned with the HTTP status codes convention for easy of implementation as it should be expressive enough and directly translates to the codes that shall be sent in the HTTP responses to clients.

In order to use this framework, adapters shall normalize their error codes and then wrap the `Error` objects using `toError()`. The router then checks if the error was wrapped and, in that case, assume `error.code` is exactly what has to be sent back to clients.