### PR TITLE
Cast ObjectId strings in stored link filters

### DIFF
--- a/lib/adapters/mongodb.js
+++ b/lib/adapters/mongodb.js
@@ -6,6 +6,35 @@ const { ensureQueryArray } = require('../querytree');
 const Promise = RSVP.Promise;
 mongoose.Promise = Promise;
 
+function isValidObjectIdString(value) {
+  return _.isString(value) && mongoose.Types.ObjectId.isValid(value);
+}
+
+function castStoredLinkQueryValue(value) {
+  if (isValidObjectIdString(value)) return new mongoose.Types.ObjectId(value);
+
+  if (_.isArray(value)) return value.map(castStoredLinkQueryValue);
+
+  if (_.isPlainObject(value)) {
+    return _.mapValues(value, function (nestedValue) {
+      return castStoredLinkQueryValue(nestedValue);
+    });
+  }
+
+  return value;
+}
+
+function castStoredLinksQuery(query) {
+  if (_.isArray(query)) return query.map(castStoredLinksQuery);
+
+  if (!_.isPlainObject(query)) return query;
+
+  return _.mapValues(query, function (value, key) {
+    if (key.indexOf('_links.') === 0) return castStoredLinkQueryValue(value);
+    return castStoredLinksQuery(value);
+  });
+}
+
 const createAdapter = function () {
   const adapter = {};
 
@@ -665,6 +694,7 @@ const createAdapter = function () {
       //Take care of deleted resources
       query = query || {};
       if (options && !options.includeDeleted) query.deletedAt = null;
+      query = castStoredLinksQuery(query);
 
       if (count) {
         model.countDocuments(query).exec().then(resolve).catch(reject);

--- a/test/fortune/non-destructive-deletes.js
+++ b/test/fortune/non-destructive-deletes.js
@@ -295,6 +295,43 @@ module.exports = function (options) {
             });
         });
     });
+    it('should cast _links ObjectId string filters', function (done) {
+      request(baseUrl)
+        .patch('/people/' + ids.people[0])
+        .set('content-type', 'application/json')
+        .send(
+          JSON.stringify([
+            {
+              op: 'replace',
+              path: '/people/0/links/soulmate',
+              value: ids.people[1],
+            },
+          ]),
+        )
+        .expect(200)
+        .end(function (err) {
+          should.not.exist(err);
+          request(baseUrl)
+            .del('/people/' + ids.people[0])
+            .expect(204)
+            .end(function (err) {
+              should.not.exist(err);
+              request(baseUrl)
+                .get(
+                  '/people?includeDeleted=true&filter[_links.soulmate]=' +
+                    ids.people[1],
+                )
+                .expect(200)
+                .end(function (err, res) {
+                  should.not.exist(err);
+                  var body = JSON.parse(res.text);
+                  body.people.length.should.equal(1);
+                  body.people[0].id.should.equal(ids.people[0]);
+                  done();
+                });
+            });
+        });
+    });
     it('should be able to delete resource destructively', function (done) {
       request(baseUrl)
         .del('/people/' + ids.people[0] + '?destroy=1')


### PR DESCRIPTION
## Summary
- Cast valid ObjectId strings in Mongo filters targeting `_links.*`
- Support nested query structures such as `$or`, `$and`, arrays, and `$in`
- Preserve non-ObjectId values unchanged

## Context
Soft-deleted resources keep their original refs in `_links`. Since `_links` is a mixed object field, Mongoose does not cast string ids there automatically. This allows queries like `filter[_links.user]=<id>` to match stored ObjectId refs.
